### PR TITLE
Remote: Change "sh -c" to "sh -lc" to make config in $HOME/.profile effective

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -450,7 +450,7 @@ impl SshSocket {
     }
 
     async fn platform(&self) -> Result<SshPlatform> {
-        let uname = self.run_command("sh", &["-c", "uname -sm"]).await?;
+        let uname = self.run_command("sh", &["-lc", "uname -sm"]).await?;
         let Some((os, arch)) = uname.split_once(" ") else {
             anyhow::bail!("unknown uname: {uname:?}")
         };
@@ -481,7 +481,7 @@ impl SshSocket {
     }
 
     async fn shell(&self) -> String {
-        match self.run_command("sh", &["-c", "echo $SHELL"]).await {
+        match self.run_command("sh", &["-lc", "echo $SHELL"]).await {
             Ok(shell) => shell.trim().to_owned(),
             Err(e) => {
                 log::error!("Failed to get shell: {e}");
@@ -1538,7 +1538,7 @@ impl RemoteConnection for SshRemoteConnection {
 
         let ssh_proxy_process = match self
             .socket
-            .ssh_command("sh", &["-c", &start_proxy_command])
+            .ssh_command("sh", &["-lc", &start_proxy_command])
             // IMPORTANT: we kill this process when we drop the task that uses it.
             .kill_on_drop(true)
             .spawn()
@@ -1915,7 +1915,7 @@ impl SshRemoteConnection {
                 .run_command(
                     "sh",
                     &[
-                        "-c",
+                        "-lc",
                         &shell_script!("mkdir -p {parent}", parent = parent.to_string().as_ref()),
                     ],
                 )
@@ -1993,7 +1993,7 @@ impl SshRemoteConnection {
                 .run_command(
                     "sh",
                     &[
-                        "-c",
+                        "-lc",
                         &shell_script!("mkdir -p {parent}", parent = parent.to_string().as_ref()),
                     ],
                 )
@@ -2041,7 +2041,7 @@ impl SshRemoteConnection {
                 dst_path = &dst_path.to_string()
             )
         };
-        self.socket.run_command("sh", &["-c", &script]).await?;
+        self.socket.run_command("sh", &["-lc", &script]).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Release Notes:

- The environment of original remote dev cannot be changed without sudo because of the behavior of "sh -c". This PR changes "sh -c" to "sh -lc" to let the shell source $HOME/.profile and support customized environment like customized $PATH variable.
